### PR TITLE
fix: PRクローズ時のプレビュー削除が動作しない問題を修正

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        if: github.event.action != 'closed'
 
       - uses: pnpm/action-setup@v4
         if: github.event.action != 'closed'


### PR DESCRIPTION
## 概要

- PRクローズ時に `actions/checkout` がスキップされ、`pr-preview-action` がgh-pagesからプレビューを削除できなかった問題を修正

## 変更内容

- `actions/checkout` の `if: github.event.action != 'closed'` 条件を削除し、常にチェックアウトが実行されるようにした
- ビルド関連ステップ（pnpm, node, install, build）のスキップ条件はそのまま維持

## テスト計画

- [ ] PRを作成してプレビューがデプロイされることを確認
- [ ] PRをクローズしてプレビューが削除されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)