### PR TITLE
fix: Biomeリント警告19件を修正

### DIFF
--- a/src/game/cardQueue.ts
+++ b/src/game/cardQueue.ts
@@ -31,7 +31,12 @@ export function buildQueuedCardIndexMap(
 	const map = new Map<string, number>();
 	for (let i = 0; i < queue.length; i++) {
 		const item = queue[i];
-		if (item) map.set(item.card.id, i + 1);
+		if (!item) {
+			throw new Error(
+				`Card queue is inconsistent: missing entry at index ${i}`,
+			);
+		}
+		map.set(item.card.id, i + 1);
 	}
 	return map;
 }

--- a/src/game/cardQueue.ts
+++ b/src/game/cardQueue.ts
@@ -30,7 +30,8 @@ export function buildQueuedCardIndexMap(
 ): Map<string, number> {
 	const map = new Map<string, number>();
 	for (let i = 0; i < queue.length; i++) {
-		map.set(queue[i]!.card.id, i + 1);
+		const item = queue[i];
+		if (item) map.set(item.card.id, i + 1);
 	}
 	return map;
 }

--- a/src/game/debugStart.test.ts
+++ b/src/game/debugStart.test.ts
@@ -6,6 +6,10 @@ import {
 	PLAYER_INITIAL_HP,
 } from "../constants";
 import { createTestState } from "../test-utils/createTestFixtures";
+import type {
+	DebugDeckComposition,
+	DebugEnemyComposition,
+} from "../types/debug";
 import { RNG } from "../utils/rng";
 import {
 	createDebugDeckState,
@@ -58,28 +62,40 @@ describe("debugStart", () => {
 		it("不正なカードタイプを指定した場合はエラーになる", () => {
 			const rng = new RNG(42);
 			expect(() => {
-				createDebugDeckState({ foo: 1 } as any, rng);
+				createDebugDeckState(
+					{ foo: 1 } as unknown as DebugDeckComposition,
+					rng,
+				);
 			}).toThrow();
 		});
 
 		it("負の count を指定した場合はエラーになる", () => {
 			const rng = new RNG(42);
 			expect(() => {
-				createDebugDeckState({ attack: -1 } as any, rng);
+				createDebugDeckState(
+					{ attack: -1 } as unknown as DebugDeckComposition,
+					rng,
+				);
 			}).toThrow();
 		});
 
 		it("小数の count を指定した場合はエラーになる", () => {
 			const rng = new RNG(42);
 			expect(() => {
-				createDebugDeckState({ attack: 1.5 } as any, rng);
+				createDebugDeckState(
+					{ attack: 1.5 } as unknown as DebugDeckComposition,
+					rng,
+				);
 			}).toThrow();
 		});
 
 		it("NaN の count を指定した場合はエラーになる", () => {
 			const rng = new RNG(42);
 			expect(() => {
-				createDebugDeckState({ attack: Number.NaN } as any, rng);
+				createDebugDeckState(
+					{ attack: Number.NaN } as unknown as DebugDeckComposition,
+					rng,
+				);
 			}).toThrow();
 		});
 	});
@@ -148,7 +164,7 @@ describe("debugStart", () => {
 			expect(() =>
 				createDebugEnemies(positions, {
 					foo: 1,
-				} as any),
+				} as unknown as DebugEnemyComposition),
 			).toThrow();
 		});
 
@@ -156,7 +172,7 @@ describe("debugStart", () => {
 			expect(() =>
 				createDebugEnemies(positions, {
 					normal: -1,
-				} as any),
+				} as unknown as DebugEnemyComposition),
 			).toThrow();
 		});
 
@@ -164,7 +180,7 @@ describe("debugStart", () => {
 			expect(() =>
 				createDebugEnemies(positions, {
 					normal: 1.5,
-				} as any),
+				} as unknown as DebugEnemyComposition),
 			).toThrow();
 		});
 
@@ -172,7 +188,7 @@ describe("debugStart", () => {
 			expect(() =>
 				createDebugEnemies(positions, {
 					normal: Infinity,
-				} as any),
+				} as unknown as DebugEnemyComposition),
 			).toThrow();
 		});
 
@@ -180,7 +196,7 @@ describe("debugStart", () => {
 			expect(() =>
 				createDebugEnemies(positions, {
 					normal: NaN,
-				} as any),
+				} as unknown as DebugEnemyComposition),
 			).toThrow();
 		});
 	});

--- a/src/game/map.ts
+++ b/src/game/map.ts
@@ -140,7 +140,8 @@ export function generateBSPMapPlacement(
 		// プレイヤー/敵はすべての床タイルからサンプリング
 		const playerEnemyCount = 1 + enemyCount;
 		const playerEnemySampled = rng.sample(floorPositions, playerEnemyCount);
-		const player = playerEnemySampled[0]!;
+		const player = playerEnemySampled[0];
+		if (!player) continue;
 		const enemies = playerEnemySampled.slice(1);
 
 		// 階段は部屋内の床タイルからサンプリング（通路に配置しない）
@@ -154,7 +155,8 @@ export function generateBSPMapPlacement(
 		);
 		if (roomFloorForStairs.length < STAIRS_COUNT) continue;
 		const stairsSampled = rng.sample(roomFloorForStairs, STAIRS_COUNT);
-		const stairs = stairsSampled[0]!;
+		const stairs = stairsSampled[0];
+		if (!stairs) continue;
 		map[stairs.y][stairs.x] = createStairsTile();
 
 		// 特殊タイルは部屋内の床タイルからサンプリング（既配置位置を除外）

--- a/src/ui/damagePopup.ts
+++ b/src/ui/damagePopup.ts
@@ -2,7 +2,7 @@
  * ダメージ/回復/MISSポップアップのアニメーション関数
  */
 
-import { Container, Text } from "pixi.js";
+import { type Container, Text } from "pixi.js";
 import { CELL_SIZE } from "../constants";
 import type { Position } from "../types";
 import { tween } from "../utils/tween";

--- a/src/ui/deckViewer.test.ts
+++ b/src/ui/deckViewer.test.ts
@@ -158,7 +158,7 @@ describe("DeckViewer", () => {
 			);
 			expect(firstRow).toBeDefined();
 			const expectedListX = (gameAreaWidth - CARD_ROW_LIST_WIDTH) / 2;
-			expect(firstRow!.x).toBe(expectedListX);
+			expect(firstRow?.x).toBe(expectedListX);
 		});
 
 		it("コンテンツがgameAreaHeightの中央に配置される", () => {

--- a/src/ui/deckViewer.test.ts
+++ b/src/ui/deckViewer.test.ts
@@ -156,9 +156,11 @@ describe("DeckViewer", () => {
 			const firstRow = container.children.find(
 				(child) => child.label === "card-row",
 			);
-			expect(firstRow).toBeDefined();
+			if (!firstRow) {
+				throw new Error("card-row element not found");
+			}
 			const expectedListX = (gameAreaWidth - CARD_ROW_LIST_WIDTH) / 2;
-			expect(firstRow?.x).toBe(expectedListX);
+			expect(firstRow.x).toBe(expectedListX);
 		});
 
 		it("コンテンツがgameAreaHeightの中央に配置される", () => {

--- a/src/ui/mapAnimationConstants.ts
+++ b/src/ui/mapAnimationConstants.ts
@@ -2,7 +2,7 @@
  * マップ描画関連の定数・純粋ヘルパー関数
  */
 
-import { Graphics } from "pixi.js";
+import type { Graphics } from "pixi.js";
 import { CELL_SIZE } from "../constants";
 import type { EnemyType } from "../types/character";
 

--- a/src/ui/mapEffects.ts
+++ b/src/ui/mapEffects.ts
@@ -2,7 +2,7 @@
  * 画面シェイク・フラッシュ・点滅エフェクト関数
  */
 
-import { Container, Graphics, Sprite, Ticker } from "pixi.js";
+import { type Container, Graphics, type Sprite, Ticker } from "pixi.js";
 import { CELL_SIZE } from "../constants";
 import { tween } from "../utils/tween";
 import {

--- a/src/ui/mapTileRenderer.ts
+++ b/src/ui/mapTileRenderer.ts
@@ -2,7 +2,7 @@
  * タイル描画・残骸・Fog of War の関数
  */
 
-import { Container, Graphics, Sprite } from "pixi.js";
+import { type Container, type Graphics, Sprite } from "pixi.js";
 import { CELL_SIZE } from "../constants";
 import type { GameMap } from "../types";
 import { getTileTexture } from "./assetLoader";

--- a/src/ui/specialTileEffect.ts
+++ b/src/ui/specialTileEffect.ts
@@ -71,9 +71,11 @@ export class SpecialTileEffectManager {
 		const newStairsEffects = new Map<string, TileEffect>();
 
 		for (let y = 0; y < map.length; y++) {
-			const row = map[y]!;
+			const row = map[y];
+			if (!row) continue;
 			for (let x = 0; x < row.length; x++) {
-				const tile = row[x]!;
+				const tile = row[x];
+				if (!tile) continue;
 				const key = `${x},${y}`;
 
 				if (tile.type === "stairs") {

--- a/src/ui/specialTileEffect.ts
+++ b/src/ui/specialTileEffect.ts
@@ -70,12 +70,8 @@ export class SpecialTileEffectManager {
 		const newEffects = new Map<string, TileEffect>();
 		const newStairsEffects = new Map<string, TileEffect>();
 
-		for (let y = 0; y < map.length; y++) {
-			const row = map[y];
-			if (!row) continue;
-			for (let x = 0; x < row.length; x++) {
-				const tile = row[x];
-				if (!tile) continue;
+		for (const [y, row] of map.entries()) {
+			for (const [x, tile] of row.entries()) {
 				const key = `${x},${y}`;
 
 				if (tile.type === "stairs") {


### PR DESCRIPTION
## 概要
- **useImportType** (4件): 型のみで使用されるimportに `type` キーワードを追加（`damagePopup.ts`, `mapAnimationConstants.ts`, `mapEffects.ts`, `mapTileRenderer.ts`）
- **noNonNullAssertion** (6件): 非nullアサーション (`!`) をガード付きの安全なパターンに置換（`cardQueue.ts`, `map.ts`, `deckViewer.test.ts`, `specialTileEffect.ts`）
- **noExplicitAny** (9件): テストの `as any` を `as unknown as Type` に変更し型安全性を明示（`debugStart.test.ts`）

## テスト計画
- [x] `pnpm lint` で警告が0件になることを確認
- [x] `pnpm build` でビルドが成功することを確認
- [x] `pnpm test:run` で全1218テストが通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)